### PR TITLE
Fix yOffset computation and fix tests

### DIFF
--- a/.jestrc
+++ b/.jestrc
@@ -8,4 +8,5 @@
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
   }
+  "setupTestFrameworkScriptFile": "<rootDir>src/setupTests.js"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.3",
     "enzyme": "^3.2.0",
+    "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.12.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-flowtype": "^2.39.1",

--- a/src/components/LeftBar/LeftBar.component.js
+++ b/src/components/LeftBar/LeftBar.component.js
@@ -1,7 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import Staffing from '../Staffing';
+import {
+  PLANNING_ROW_PADDING,
+  TASK_HEIGHT,
+} from '../Staffing/constants';
 
 type Props = {
   rows: Array,
@@ -33,7 +36,7 @@ type UserProps = {
 class User extends React.Component<UserProps> {
   render() {
     const style = {
-      height: `${this.props.maxWeeklyTasksCount * Staffing.TASK_HEIGHT + Staffing.PLANNING_ROW_PADDING}px`,
+      height: `${this.props.maxWeeklyTasksCount * TASK_HEIGHT + PLANNING_ROW_PADDING}px`,
     };
 
     return (

--- a/src/components/Planning/Planning.component.js
+++ b/src/components/Planning/Planning.component.js
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import moment from 'moment';
 import Task from '../Task';
-import Staffing from '../Staffing';
 import Standards from '../Standards';
+import {
+  PLANNING_ROW_PADDING,
+  TASK_HEIGHT,
+  WEEK_WIDTH,
+} from '../Staffing/constants';
 
 export default class Planning extends React.Component {
   componentDidMount() {
@@ -13,7 +17,7 @@ export default class Planning extends React.Component {
   }
 
   getWeekOffset(week) {
-    return Staffing.WEEK_WIDTH * (week - this.props.weeks[0].format('w'));
+    return WEEK_WIDTH * (week - this.props.weeks[0].format('w'));
   }
 
   initializeScroll() {
@@ -39,7 +43,7 @@ row =>
                 <div
                   key={row.user.username}
                   className="planning-row"
-                  style={{ height: `${row.maxWeeklyTasksCount * Staffing.TASK_HEIGHT + Staffing.PLANNING_ROW_PADDING}px` }}
+                  style={{ height: `${row.maxWeeklyTasksCount * TASK_HEIGHT + PLANNING_ROW_PADDING}px` }}
                 >
                   {
                     row.tasks.map(task => (<Task

--- a/src/components/Staffing/constants.js
+++ b/src/components/Staffing/constants.js
@@ -1,0 +1,4 @@
+export const WEEK_WIDTH = 244;
+export const DAY_WIDTH = WEEK_WIDTH / 7;
+export const TASK_HEIGHT = 35;
+export const PLANNING_ROW_PADDING = 5;

--- a/src/components/__tests__/Staffing.test.js
+++ b/src/components/__tests__/Staffing.test.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import Staffing from '../Staffing';
+import LeftBar from '../LeftBar';
+import Planning from '../Planning';
+import Staffing from '../Staffing/Staffing.component';
+import TopBar from '../TopBar';
 
 describe('Staffing test suites', () => {
   const users = [
@@ -25,7 +28,9 @@ describe('Staffing test suites', () => {
   const staffing = shallow(<Staffing users={users} weeks={weeks} timeline={[]} />);
 
   it('should render without throwing an error', () => {
-    expect(staffing.is('.scrollable-wrapper')).toBe(true);
+    expect(staffing.find(LeftBar).length).toEqual(1);
+    expect(staffing.find(Planning).length).toEqual(1);
+    expect(staffing.find(TopBar).length).toEqual(1);
   });
 
   it('should return the x and y offsets of a task', () => {
@@ -41,7 +46,7 @@ describe('Staffing test suites', () => {
       yoffset: Staffing.PLANNING_ROW_PADDING,
     };
 
-    expect(staffing.instance()._calculateTaskOffsets(task, weeklyTasks)).toMatchObject(expectedPosition);
+    expect(staffing.instance().calculateTaskOffsets(task, weeklyTasks)).toMatchObject(expectedPosition);
   });
 
   it('should return the x an y offsets of task starting on tuesday', () => {
@@ -57,7 +62,7 @@ describe('Staffing test suites', () => {
       yoffset: Staffing.PLANNING_ROW_PADDING,
     };
 
-    expect(staffing.instance()._calculateTaskOffsets(task, weeklyTasks)).toMatchObject(expectedPosition);
+    expect(staffing.instance().calculateTaskOffsets(task, weeklyTasks)).toMatchObject(expectedPosition);
   });
 
   it('should return the x and y offsets of a task overlaping another one', () => {
@@ -73,7 +78,7 @@ describe('Staffing test suites', () => {
       yoffset: Staffing.TASK_HEIGHT + Staffing.PLANNING_ROW_PADDING,
     };
 
-    expect(staffing.instance()._calculateTaskOffsets(overlapingTask, weeklyTasks)).toMatchObject(expectedPosition);
+    expect(staffing.instance().calculateTaskOffsets(overlapingTask, weeklyTasks)).toMatchObject(expectedPosition);
   });
 
   it('should return the x and y offsets of a task overlaping two other tasks', () => {
@@ -91,6 +96,6 @@ describe('Staffing test suites', () => {
       yoffset: Staffing.TASK_HEIGHT * 2 + Staffing.PLANNING_ROW_PADDING,
     };
 
-    expect(staffing.instance()._calculateTaskOffsets(overlapingTask, weeklyTasks)).toMatchObject(expectedPosition);
+    expect(staffing.instance().calculateTaskOffsets(overlapingTask, weeklyTasks)).toMatchObject(expectedPosition);
   });
 });

--- a/src/components/__tests__/Staffing.test.js
+++ b/src/components/__tests__/Staffing.test.js
@@ -98,4 +98,19 @@ describe('Staffing test suites', () => {
 
     expect(staffing.instance().calculateTaskOffsets(overlapingTask, weeklyTasks)).toMatchObject(expectedPosition);
   });
+
+  it('should return correct offsets of a task than spans over 2 years', () => {
+    const weeklyTasks = {
+      52: 0,
+      53: 1,
+    };
+    const task = {
+      startDate: '25/12/2017',
+      endDate: '07/01/2018',
+    };
+    const expectedPosition = {
+      yoffset: Staffing.TASK_HEIGHT + Staffing.PLANNING_ROW_PADDING,
+    };
+    expect(staffing.instance().calculateTaskOffsets(task, weeklyTasks)).toMatchObject(expectedPosition);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,11 @@ const initialState = {
   timeline,
   weeks,
 };
-const store = createStore(combineReducers({}), initialState);
+const store = createStore(
+  combineReducers({}),
+  initialState,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
 
 const rootEl = document.getElementById('app');
 

--- a/src/services/Task.js
+++ b/src/services/Task.js
@@ -2,11 +2,11 @@
 
 import moment from 'moment';
 
-import Staffing from '../components/Staffing';
+import { DAY_WIDTH } from '../components/Staffing/constants';
 
 export const calculateTaskWidth = (task) => {
   const taskLength = moment(task.endDate).diff(moment(task.startDate), 'days');
-  const length = taskLength * Staffing.DAY_WIDTH;
+  const length = taskLength * DAY_WIDTH;
 
   return Math.ceil(length - 10);
 };

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
La façon dont le yOffset de tasks était calculée faisait qu'il y avait des taches cachées par d'autres taches : par ex "Echoline" de maximet était sous le "Allomatch".

Il y avait 2 problèmes dans le calcul:

1. Dans la transformation date->semaine on ne prenait pas en compte l'année => 01/01/2017 et 01/01/2018 étaient toutes les deux transformées en semaine "1". Après le fix on ajoute +52 aux semaines de l'année 2018.

2. On calculait le yOffset en fonction de weeklyTasks[1re semaine du task].
Alors qu'il faut le calculer en fonction de max de {weeklyTasks[semaine] pour toutes les semaines du task}